### PR TITLE
Provide original Request object to response callback

### DIFF
--- a/RestifizerRequest.cs
+++ b/RestifizerRequest.cs
@@ -236,15 +236,15 @@ namespace Restifizer {
 					if (errorHandler != null) {
 						bool propagateResult = !errorHandler.onRestifizerError(error);
 						if (propagateResult) {
-							callback(new RestifizerResponse(request.response.status, error, tag));
+							callback(new RestifizerResponse(request, error, tag));
 						}
 					} else {
-						callback(new RestifizerResponse(request.response.status, error, tag));
+						callback(new RestifizerResponse(request, error, tag));
 					}
 				} else if (responseResult is ArrayList) {
-					callback(new RestifizerResponse(request.response.status, (ArrayList)responseResult, tag));
+					callback(new RestifizerResponse(request, (ArrayList)responseResult, tag));
 				} else if (responseResult is Hashtable) {
-					callback(new RestifizerResponse(request.response.status, (Hashtable)responseResult, tag));
+					callback(new RestifizerResponse(request, (Hashtable)responseResult, tag));
 				} else {
 					Debug.LogWarning("Unsupported type in response: " + responseResult.GetType());
 					callback(null);

--- a/RestifizerResponse.cs
+++ b/RestifizerResponse.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using System.Collections;
+using HTTP;
 
 namespace Restifizer {
 	public class RestifizerResponse {
@@ -10,27 +11,31 @@ namespace Restifizer {
 		public RestifizerError Error;
 		public int Status;
 		public string Tag;
+		public HTTP.Request Request;
 		
-		public RestifizerResponse(int status, Hashtable result, string tag) {
+		public RestifizerResponse(HTTP.Request request, Hashtable result, string tag) {
 			this.IsList = false;
-			this.Status = status;
+			this.Status = request.response.status;
 			this.Resource = result;
 			this.HasError = false;
+			this.Request = request;
             this.Tag = tag;
 		}
 
-		public RestifizerResponse(int status, ArrayList result, string tag) {
+		public RestifizerResponse(HTTP.Request request, ArrayList result, string tag) {
 			this.IsList = true;
-			this.Status = status;
+			this.Status = request.response.status;
 			this.ResourceList = result;
             this.HasError = false;
+			this.Request = request;
 			this.Tag = tag;
 		}
 
-		public RestifizerResponse(int status, RestifizerError error, string tag) {
-			this.Status = status;
+		public RestifizerResponse(HTTP.Request request, RestifizerError error, string tag) {
+			this.Status = request.response.status;
 			this.HasError = true;
 			this.Error = error;
+			this.Request = request;
 			this.Tag = tag;
 		}
 	}


### PR DESCRIPTION
I needed to receive a response as text together with a parsed data. The best way to do it is to change a constructor of RestifizerResponse to accept HTTP.Request object. This doesn't change any external API and simplifies logic of RestifizerRequest, where RestifizerResponse was constructed using request.response.status in every instance
